### PR TITLE
Support Java8+ targets

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -12,6 +12,8 @@
   :java-source-paths ["src/java"]
   :test-paths ["test/clj"]
 
+  :javac-options ["-target" "1.8" "-source" "1.8"]
+
   :eftest {:fail-fast? true}
 
   :dependencies [[org.clojure/clojure "1.11.2"]


### PR DESCRIPTION
Running this project on my local machine with Java21 results in the following exception at startup time:

```
org/clojars/mjdrogalis/avroexplain/ExplainAvro has been compiled by a more recent version of the Java Runtime (class file version 67.0), this version of the Java Runtime only recognizes class file versions up to 65.0
```

Makes sense, I guess you are running Java23 when deploying to Clojars: https://javaalmanac.io/bytecode/versions/

Adding explicit `:javac-options` to the project so that the associated Java sources work with Java8+ should fix this problem.

We'd love to use the project inside of our product - [Kpow](https://factorhouse.io/kpow)! However, we require Java8+ use. 

